### PR TITLE
Remove unused bind_host and bind_port from the heat-engine.conf

### DIFF
--- a/etc/heat/heat-engine.conf
+++ b/etc/heat/heat-engine.conf
@@ -5,12 +5,6 @@ verbose = True
 # Show debugging output in logs (sets DEBUG log level output)
 debug = True
 
-# Address to bind the server to
-bind_host = 0.0.0.0
-
-# Port the bind the server to
-bind_port = 8001
-
 # Keystone role for heat template-defined users
 heat_stack_user_role = heat_stack_user
 


### PR DESCRIPTION
These are not used.
To avoid confusion these should not be in the config file
