### PR TITLE
Enable get the scaling group instance list of stack resource

### DIFF
--- a/heat/engine/api.py
+++ b/heat/engine/api.py
@@ -130,6 +130,9 @@ def format_stack_resource(resource, detail=True):
         api.RES_REQUIRED_BY: resource.required_by(),
     }
 
+    if hasattr(resource, 'instance_list'):
+        res[api.RES_SG_INST] = resource.instance_list
+
     if detail:
         res[api.RES_DESCRIPTION] = resource.parsed_template('Description', '')
         res[api.RES_METADATA] = resource.metadata

--- a/heat/rpc/api.py
+++ b/heat/rpc/api.py
@@ -50,13 +50,13 @@ RES_KEYS = (
     RES_NAME, RES_PHYSICAL_ID, RES_METADATA,
     RES_ACTION, RES_STATUS, RES_STATUS_DATA,
     RES_TYPE, RES_ID, RES_STACK_ID, RES_STACK_NAME,
-    RES_REQUIRED_BY,
+    RES_REQUIRED_BY, RES_SG_INST,
 ) = (
     'description', 'updated_time',
     'resource_name', 'physical_resource_id', 'metadata',
     'resource_action', 'resource_status', 'resource_status_reason',
     'resource_type', 'resource_identity', STACK_ID, STACK_NAME,
-    'required_by',
+    'required_by', 'scaling_group_instances',
 )
 
 RES_SCHEMA_KEYS = (


### PR DESCRIPTION
Currently, it's very unconvenient for scaling group during unable
to get detail information about the instance of caling group. So
we should enable to get the scaling group instance list when
descibling stack resource.

Change-Id: I5aefac09938d3dddeef284b86a627f9bbca8927a