### PR TITLE
api: pass args=[] to oslo.config in init_application

### DIFF
--- a/heat/api/cfn/wsgi.py
+++ b/heat/api/cfn/wsgi.py
@@ -37,7 +37,8 @@ def init_application():
     # already contain registered options if the app is reloaded.
     CONF.reset()
     logging.register_options(CONF)
-    CONF(project='heat',
+    CONF(args=[],
+         project='heat',
          prog='heat-api-cfn',
          version=version.version_info.version_string())
     logging.setup(CONF, CONF.prog)

--- a/heat/api/openstack/wsgi.py
+++ b/heat/api/openstack/wsgi.py
@@ -38,7 +38,7 @@ def init_application():
     CONF.reset()
     logging.register_options(CONF)
     version = hversion.version_info.version_string()
-    CONF(project='heat', prog='heat-api', version=version)
+    CONF(args=[], project='heat', prog='heat-api', version=version)
     logging.setup(CONF, CONF.prog)
     config.set_config_defaults()
     messaging.setup()

--- a/releasenotes/notes/fix-wsgi-init-args-empty-9d86398edce73f54.yaml
+++ b/releasenotes/notes/fix-wsgi-init-args-empty-9d86398edce73f54.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixed an issue where ``heat-api`` and ``heat-api-cfn``, when running
+    under uWSGI with ``wsgi-file``, could fail to load the WSGI application
+    with ``unable to load app 0 ... (callable not found or import error)``.
+    The ``init_application`` functions in ``heat.api.openstack.wsgi`` and
+    ``heat.api.cfn.wsgi`` invoked ``oslo.config`` without ``args=[]``, so
+    ``oslo.config`` fell back to ``sys.argv[1:]`` and rejected uWSGI's own
+    arguments (e.g. ``--ini``) with ``SystemExit(2)``. The calls now pass
+    an explicit empty argument list.


### PR DESCRIPTION
## Summary

Fix heat-api / heat-api-cfn failing to load WSGI app under uWSGI with `wsgi-file`. `init_application()` calls `oslo.config` without `args`, so it falls back to `sys.argv[1:]` and chokes on uWSGI's own `--ini` argument with `SystemExit(2)`. Pass `args=[]` explicitly.

Affects both `heat/api/cfn/wsgi.py` and `heat/api/openstack/wsgi.py`.

## Reproduction

In a uWSGI deployment using:
```
[uwsgi]
http-socket = 0.0.0.0:8000
wsgi-file = /var/lib/openstack/bin/heat-wsgi-api-cfn
```
The pod stays Running but every HTTP request returns 500 with:
```
unable to load app 0 (mountpoint='') (callable not found or import error)
*** no app loaded. going in full dynamic mode ***
```

## Verified

End-to-end reproduced and fix-verified inside a real `quay.io/airshipit/heat:2025.2-ubuntu_noble` container: with the patched `init_application`, the WSGI callable loads (`<class 'oslo_middleware.cors.CORS'>`); without the patch it raises `SystemExit(2)`.

## Test plan

- [x] Run `init_application()` with `sys.argv = ["uwsgi", "--ini", ...]` — no longer SystemExit.
- [ ] CI: pep8, py3, functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)